### PR TITLE
refactor: swagger 라우터 변경

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,20 +1,28 @@
 from flask import Flask
 from flask_cors import CORS
 from app.prefix_middleware import PrefixMiddleware
+from app.views.test_views import test_ns
+from flask_restx import Api, Resource, reqparse
 
 def create_app():
     app = Flask(__name__)
     CORS(app, resources={r"/*": {"origins": "*"}})
     app.config['SECRET_KEY'] = 'secret!'
     
-    # 라우터 prefix 고정시키기
-    app.wsgi_app = PrefixMiddleware(app.wsgi_app, prefix='/api/ai')
+    #swagger 등록하기
     
-    @app.route("/test")
-    def getTest():
-        return {"test":True}
+    api = Api(app, version='1.0', title='API 문서', description='Swagger 문서', doc="/api-docs")
+    
+    
+    # 라우터 prefix 고정시키기
+    app.wsgi_app = PrefixMiddleware(
+        app.wsgi_app,
+        prefix='/api/ai',
+        exclude_paths=['/api-docs', '/swaggerui', '/swagger.json']  # Swagger 관련 경로 제외
+    )
     
     # 라우터 등록하기
+    api.add_namespace(test_ns, path='/test')
     # router_bp
     # statics_bp
     

--- a/app/prefix_middleware.py
+++ b/app/prefix_middleware.py
@@ -1,11 +1,19 @@
 class PrefixMiddleware:
-    def __init__(self, app, prefix):
+    def __init__(self, app, prefix, exclude_paths=None):
         self.app = app
         self.prefix = prefix
+        self.exclude_paths = exclude_paths or []
 
     def __call__(self, environ, start_response):
-        if environ['PATH_INFO'].startswith(self.prefix):
-            environ['PATH_INFO'] = environ['PATH_INFO'][len(self.prefix):]
+        path = environ.get('PATH_INFO', '')
+
+        # exclude_paths 중 하나라도 path가 시작되면 미들웨어 적용하지 않고 바로 app 호출
+        for exclude in self.exclude_paths:
+            if path.startswith(exclude):
+                return self.app(environ, start_response)
+
+        if path.startswith(self.prefix):
+            environ['PATH_INFO'] = path[len(self.prefix):]
             environ['SCRIPT_NAME'] = self.prefix
             return self.app(environ, start_response)
         else:

--- a/app/views/test_views.py
+++ b/app/views/test_views.py
@@ -1,0 +1,8 @@
+from flask_restx import Namespace, Resource
+
+test_ns = Namespace('test', description='테스트 네임스페이스')
+
+@test_ns.route('/')
+class TestResource(Resource):
+    def get(self):
+        return {"test": True}


### PR DESCRIPTION
## 작업 대상

> 기존 Blueprint 기반 라우팅을 Flask-RESTX Namespace 기반 Swagger 문서화 구조로 전환했습니다.

- Swagger 연동
- 라우팅 구조 개선 (Blueprint 제거)

## 작업 내용

- [x] Flask-RESTX (`Namespace`, `Resource`) 구조 도입
- [x] Swagger UI 경로 `/api-docs`로 설정
- [x] 기존 Blueprint 코드 제거
- [x] 테스트용 API (`/test`)를 Namespace로 구현
- [x] PrefixMiddleware에서 Swagger 경로 제외 처리

## 작업 파일

| 종류      | 파일명                      | 변경사항                                 |
|----------|-----------------------------|------------------------------------------|
| 신규 생성 | `view/test_view.py`  | 테스트용 Swagger API (`/test`) 등록       |
| 수정     | `app/__init__.py`                    | Api 및 Namespace 등록, Blueprint 제거     |
| 수정     | `prefix_middleware.py`      | Swagger 관련 경로 제외 로직 추가           |

## 리뷰받고 싶은 사항

- Namespace 분리 방식이 확장성과 유지보수 측면에서 괜찮은 구조인지

## 기타 참고사항

- Swagger 문서 UI : (http://~/api-docs)
- API 실제 요청은 `/api/ai/test` 아래에서 동작함
